### PR TITLE
Remove mocking of subprocess

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -9,6 +9,4 @@ def test_runner(skill, example, emitter, loader, m1):
 
     m1.side_effect = side_effect
     s = [s for s in loader.skills if s and s.root_dir == skill][0]
-    with mock.patch(s.__module__ + '.check_output') as m2:
-        m2.return_value = b'Test'
-        return SkillTest(skill, example, emitter).run(loader)
+    return SkillTest(skill, example, emitter).run(loader)


### PR DESCRIPTION
subprocess is no longer used by the skill so the test would fail constantly