### PR TITLE
Resolve SSL issue on Picroft

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyopenssl


### PR DESCRIPTION
Adds `pyopenssl` as required package to resolve SSL issue connecting to 0x0.st from Picroft.

See [PR #991](https://github.com/MycroftAI/mycroft-skills/pull/991) for more details.

Should be removed in the future when no longer needed.