### PR TITLE
update import of mock - no longer an independent package

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,6 +1,6 @@
 from test.integrationtests.skills.skill_tester import SkillTest
 
-import mock
+from unittest import mock
 
 
 @mock.patch('mycroft.skills.mycroft_skill.mycroft_skill.DeviceApi.send_email')


### PR DESCRIPTION
#### Description
Mock was still being imported as a standalone package rather than using the new inbuilt `unittest.mock`

Thanks to @PureTryOut for spotting this.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
`mycroft-skill-testrunner /path/to/this/skill`

#### CLA
- [x] Yes