### PR TITLE
Add device ID's to troubleshooting package

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,7 +19,7 @@ from mycroft import MycroftSkill, intent_handler
 
 from .skill.audio_recorder import ThreadedRecorder
 from .skill.debug_package import create_debug_package
-from .skill.device_id import get_device_name
+from .skill.device_id import get_device_name, get_mycroft_uuid, get_pantacor_device_id
 from .skill.upload import upload_debug_package
 
 
@@ -64,12 +64,23 @@ class SupportSkill(MycroftSkill):
         data = {
             "url": url,
             "device_name": get_device_name(),
+            "device_uuid": get_mycroft_uuid(),
+            "pantacor_id": "",
             "description": description,
         }
+        if self.is_pantacor_device:
+            pantacor_id = get_pantacor_device_id()
+            data["pantacor_id"] = f"<p><b>Pantacor ID:</b> {pantacor_id}</p>"
         email = "\n".join(self.translate_template("support.email", data))
         title = self.translate("support.title")
         self.send_email(title, email)
         self.speak_dialog("complete")
+
+    @property
+    def is_pantacor_device(self) -> bool:
+        """Check if current device is using Pantacor"""
+        packaging_type = self.config_core["enclosure"].get("packaging_type", "unknown")
+        return packaging_type == "pantacor"
 
 
 def create_skill():

--- a/__init__.py
+++ b/__init__.py
@@ -29,13 +29,9 @@ class SupportSkill(MycroftSkill):
     @intent_handler("contact.support.intent")
     def troubleshoot(self):
         # Get a problem description from the user
-        user_words = self.get_response("confirm.support", num_retries=0)
+        confirmation = self.ask_yesno("confirm.support")
 
-        yes_words = self.translate_list("yes")
-
-        # TODO: .strip() shouldn't be needed, translate_list should remove
-        #       the '\r' I'm seeing.  Remove after bugfix.
-        if not user_words or not any(i.strip() in user_words for i in yes_words):
+        if confirmation != "yes":
             self.speak_dialog("cancelled")
             return
 

--- a/__init__.py
+++ b/__init__.py
@@ -12,136 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from os import chdir
 
-import shutil
-from glob import glob
-from tempfile import mkstemp, mkdtemp
-from threading import Thread, Event
+from tempfile import mkstemp
 
-from os.path import dirname, join, isfile
-import requests
-from zipfile import ZipFile, ZIP_DEFLATED
-
-import mycroft
 from mycroft import MycroftSkill, intent_handler
-from mycroft.api import DeviceApi
 
-import pyaudio
-import wave
-
-
-class AudioRecorder:
-    def __init__(self, **params):
-        params.setdefault("format", pyaudio.paInt16)
-        params.setdefault("channels", 1)
-        params.setdefault("rate", 16000)
-        params.setdefault("frames_per_buffer", 1024)
-        self.audio = pyaudio.PyAudio()
-        self.stream = self.audio.open(input=True, **params)
-        self.params = params
-        self.frames = []
-
-    def update(self):
-        self.frames.append(self.stream.read(self.params["frames_per_buffer"]))
-
-    def stop(self):
-        if not self.stream.is_stopped():
-            self.stream.stop_stream()
-            self.stream.close()
-            self.audio.terminate()
-
-    def save(self, filename):
-        self.stop()
-        with wave.open(filename, "wb") as wf:
-            wf.setnchannels(self.params["channels"])
-            wf.setsampwidth(self.audio.get_sample_size(self.params["format"]))
-            wf.setframerate(self.params["rate"])
-            wf.writeframes(b"".join(self.frames))
-
-
-class ThreadedRecorder(Thread, AudioRecorder):
-    def __init__(self, daemon=False, **params):
-        Thread.__init__(self, daemon=daemon)
-        AudioRecorder.__init__(self, **params)
-        self.stop_event = Event()
-        self.start()
-
-    def run(self):
-        while not self.stop_event.is_set():
-            self.update()
-
-    def stop(self):
-        if self.is_alive():
-            self.stop_event.set()
-            self.join()
-            AudioRecorder.stop(self)
+from .skill.audio_recorder import ThreadedRecorder
+from .skill.debug_package import create_debug_package
+from .skill.device_id import get_device_name
+from .skill.upload import upload_debug_package
 
 
 class SupportSkill(MycroftSkill):
-    # TODO: Will need to read from config under KDE, etc.
-    log_locations = [
-        "/opt/mycroft/*.json",
-        "/var/log/mycroft/*.log",
-        "/etc/mycroft/*.conf",
-        join(dirname(dirname(mycroft.__file__)), "scripts", "logs", "*.log"),
-    ]
-    log_types = ["audio", "bus", "enclosure", "skills", "update", "voice"]
-
-    def get_log_files(self):
-        log_files = sum([glob(pattern) for pattern in self.log_locations], [])
-        for i in self.log_locations:
-            for log_type in self.log_types:
-                fn = i.replace("*", log_type)
-                if fn in log_files:
-                    continue
-                if isfile(fn):
-                    log_files.append(fn)
-        return log_files
-
-    def create_debug_package(self, extra_files=None):
-        fd, name = mkstemp(suffix=".zip")
-        tmp_folder = mkdtemp()
-        zip_files = []
-        for file in self.get_log_files() + (extra_files or []):
-            tar_name = file.strip("/").replace("/", ".")
-            tmp_file = join(tmp_folder, tar_name)
-            shutil.copy(file, tmp_file)
-            zip_files.append(tar_name)
-
-        chdir(tmp_folder)
-        try:
-            with ZipFile(name, "w", ZIP_DEFLATED) as zf:
-                for fn in zip_files:
-                    zf.write(fn)
-        except OSError as e:
-            self.log.warning("Failed to create debug package: {}".format(e))
-            return None
-        return name
-
-    def upload_file(self, filename):
-        with open(filename, "rb") as f:
-            r = requests.post("https://0x0.st", files={"file": f})
-        if r.status_code != 200:
-            self.log.warning("Failed to post logs: {}".format(r.text))
-            return ""
-        return r.text.strip()
-
-    def get_device_name(self):
-        try:
-            return DeviceApi().get()["name"]
-        except:
-            self.log.exception("API Error")
-            return ":error:"
-
-    def upload_debug_package(self, extra_files=None):
-        package_fn = self.create_debug_package(extra_files)
-        if not package_fn:
-            return None
-        url = self.upload_file(package_fn)
-        if not url:
-            return None
-        return url
 
     # "Create a support ticket"
     @intent_handler("contact.support.intent")
@@ -157,8 +39,8 @@ class SupportSkill(MycroftSkill):
             self.speak_dialog("cancelled")
             return
 
-        sr = self.config_core["listener"]["sample_rate"]
-        recorder = ThreadedRecorder(rate=sr)
+        sample_rate = self.config_core["listener"]["sample_rate"]
+        recorder = ThreadedRecorder(rate=sample_rate)
         description = self.get_response("ask.description", num_retries=0)
         recorder.stop()
 
@@ -166,7 +48,7 @@ class SupportSkill(MycroftSkill):
             self.speak_dialog("cancelled")
             return
 
-        fd, audio_file = mkstemp(suffix=".wav")
+        _, audio_file = mkstemp(suffix=".wav")
         recorder.save(audio_file)
 
         self.speak_dialog("one.moment")
@@ -174,8 +56,10 @@ class SupportSkill(MycroftSkill):
         # Log so that the message will appear in the package of logs sent
         self.log.debug("Troubleshooting Package Description: " + str(description))
 
+        # Compile debug package
+        debug_package = create_debug_package([audio_file])
         # Upload the logs to the web
-        url = self.upload_debug_package([audio_file])
+        url = upload_debug_package(debug_package)
         if not url:
             self.speak_dialog("upload.failed")
             return  # Something failed creating package. More info in logs
@@ -183,7 +67,7 @@ class SupportSkill(MycroftSkill):
         # Create the troubleshooting email and send to user
         data = {
             "url": url,
-            "device_name": self.get_device_name(),
+            "device_name": get_device_name(),
             "description": description,
         }
         email = "\n".join(self.translate_template("support.email", data))

--- a/dialog/en-us/support.email.template
+++ b/dialog/en-us/support.email.template
@@ -2,6 +2,8 @@
 
 <ul><tt>
 <p><b>Device Name:</b> {{device_name}}</p>
+<p><b>Device Name:</b> {{device_uuid}}</p>
+{{pantacor_id}}
 <p><b>Description:</b> {{description}}</p>
 <br>
 <p>

--- a/skill/audio_recorder.py
+++ b/skill/audio_recorder.py
@@ -1,0 +1,67 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import wave
+from threading import Event, Thread
+
+import pyaudio
+
+
+class AudioRecorder:
+    def __init__(self, **params):
+        params.setdefault("format", pyaudio.paInt16)
+        params.setdefault("channels", 1)
+        params.setdefault("rate", 16000)
+        params.setdefault("frames_per_buffer", 1024)
+        self.audio = pyaudio.PyAudio()
+        self.stream = self.audio.open(input=True, **params)
+        self.params = params
+        self.frames = []
+
+    def update(self):
+        self.frames.append(self.stream.read(self.params["frames_per_buffer"]))
+
+    def stop(self):
+        if not self.stream.is_stopped():
+            self.stream.stop_stream()
+            self.stream.close()
+            self.audio.terminate()
+
+    def save(self, filename):
+        self.stop()
+        with wave.open(filename, "wb") as wf:
+            wf.setnchannels(self.params["channels"])
+            wf.setsampwidth(self.audio.get_sample_size(self.params["format"]))
+            wf.setframerate(self.params["rate"])
+            wf.writeframes(b"".join(self.frames))
+
+
+class ThreadedRecorder(Thread, AudioRecorder):
+    def __init__(self, daemon=False, **params):
+        Thread.__init__(self, daemon=daemon)
+        AudioRecorder.__init__(self, **params)
+        self.stop_event = Event()
+        self.start()
+
+    def run(self):
+        while not self.stop_event.is_set():
+            self.update()
+
+    def stop(self):
+        if self.is_alive():
+            self.stop_event.set()
+            self.join()
+            AudioRecorder.stop(self)

--- a/skill/debug_package.py
+++ b/skill/debug_package.py
@@ -1,0 +1,66 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import shutil
+from glob import glob
+from os import chdir
+from os.path import dirname, isfile, join
+from tempfile import mkdtemp, mkstemp
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import mycroft
+from mycroft.util import LOG
+
+# TODO: Will need to read from config under KDE, etc.
+# TODO: Needs to handle XDG paths
+log_locations = [
+    "/opt/mycroft/*.json",
+    "/var/log/mycroft/*.log",
+    "/etc/mycroft/*.conf",
+    join(dirname(dirname(mycroft.__file__)), "scripts", "logs", "*.log"),
+]
+log_types = ["audio", "bus", "enclosure", "skills", "update", "voice"]
+
+
+def get_log_files():
+    log_files = sum([glob(pattern) for pattern in log_locations], [])
+    for i in log_locations:
+        for log_type in log_types:
+            fn = i.replace("*", log_type)
+            if fn in log_files:
+                continue
+            if isfile(fn):
+                log_files.append(fn)
+    return log_files
+
+
+def create_debug_package(extra_files=None):
+    fd, name = mkstemp(suffix=".zip")
+    tmp_folder = mkdtemp()
+    zip_files = []
+    for file in get_log_files() + (extra_files or []):
+        tar_name = file.strip("/").replace("/", ".")
+        tmp_file = join(tmp_folder, tar_name)
+        shutil.copy(file, tmp_file)
+        zip_files.append(tar_name)
+
+    chdir(tmp_folder)
+    try:
+        with ZipFile(name, "w", ZIP_DEFLATED) as zf:
+            for fn in zip_files:
+                zf.write(fn)
+    except OSError as e:
+        LOG.warning("Failed to create debug package: {}".format(e))
+        return None
+    return name

--- a/skill/device_id.py
+++ b/skill/device_id.py
@@ -14,6 +14,7 @@
 #
 
 from mycroft.api import DeviceApi
+from mycroft.identity import IdentityManager
 from mycroft.util import LOG
 
 
@@ -23,3 +24,19 @@ def get_device_name():
     except Exception as err:
         LOG.exception("API Error", err)
         return ":error:"
+
+
+def get_mycroft_uuid():
+    """Get the UUID of a Mycroft device paired with the Mycroft backend."""
+    identity = IdentityManager.get()
+    return identity.uuid
+
+
+def get_pantacor_device_id():
+    """Get the Pantacor device-id for devices using the Pantacor update system."""
+    # Import within function as it doesn't exist on non-Mark II devices.
+    from mycroft.api import _get_pantacor_device_id
+
+    # TODO this uses the temporary solution in the feature/mark-2 branch.
+    # It should be replaced when a better solution is available.
+    return _get_pantacor_device_id()

--- a/skill/device_id.py
+++ b/skill/device_id.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from mycroft.api import DeviceApi
+from mycroft.util import LOG
+
+
+def get_device_name():
+    try:
+        return DeviceApi().get()["name"]
+    except Exception as err:
+        LOG.exception("API Error", err)
+        return ":error:"

--- a/skill/upload.py
+++ b/skill/upload.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import requests
+
+from mycroft.util import LOG
+
+
+def upload_file(filename):
+    with open(filename, "rb") as f:
+        r = requests.post("https://0x0.st", files={"file": f})
+    if r.status_code != 200:
+        LOG.warning("Failed to post logs: {}".format(r.text))
+        return ""
+    return r.text.strip()
+
+def upload_debug_package(package):
+    if not package:
+        return None
+    url = upload_file(package)
+    if not url:
+        return None
+    return url


### PR DESCRIPTION
#### Description
Adds the Mycroft UUID and if the device is using Pantacor as it's packaging type, will add the Pantacor ID - to the email sent with the debug package.

Did a general clean up of the Skill while I was here.

#### Type of PR
- [x] Feature implementation
- [x] Refactor of code (without functional changes)

#### Testing
Create a support ticket on desktop and a Mark II.
See the difference in the emails received.

#### CLA
- [x] Yes